### PR TITLE
Auto Fix by DevOps Guardian

### DIFF
--- a/fix.txt
+++ b/fix.txt
@@ -1,0 +1,5 @@
+Error:
+ModuleNotFoundError: No module named numpy
+
+Fix:
+You need to install the `numpy` module. You can do this by running the command `pip install numpy` in your terminal or command prompt. This will install the `numpy` module and should resolve the `ModuleNotFoundError`.


### PR DESCRIPTION
Automated fix:

You need to install the `numpy` module. You can do this by running the command `pip install numpy` in your terminal or command prompt. This will install the `numpy` module and should resolve the `ModuleNotFoundError`.